### PR TITLE
service step 1 of 4: adjust resources and deploy to pods

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -29,18 +29,17 @@ env:
 - SNOWFLAKE_ROLE
 - LATENCY_CONFIG
 resources:
-  cpu: 0.1
-  soft_mem_limit: 0.1
-  max_mem: 0.1
+  cpu: 0.25
+  max_mem: 0.5
 shepherds:
-- "benji.stein@clever.com"
+- benji.stein@clever.com
 expose:
 - name: default
   port: 80
   health_check:
     type: http
     path: /_health
-team: "eng-deip"
+team: eng-deip
 autoscaling:
   metric: cpu
   metric_target: 50
@@ -85,3 +84,9 @@ alarms:
   severity: minor
   parameters:
     threshold: 0.05
+pod_config:
+  dev:
+    migrationState: deployable
+  group: us-west-1
+  prod:
+    migrationState: deployable


### PR DESCRIPTION
This PR is the first step in migrating this service to pods

This PR will
- deploy to pods in dev and prod
- no traffic will go to the pod deployment
- adjust cpu and memory values based on metrics for the last 7 days to fit fargate constraints

To check before merging
- region. By default infra is migrating everything to us-west-1 but if this app talks to some dbs in us-west-2 you can run the service in us-west-2 pod
- cpu and memory. just check that the values are not unreasonable. You can go to go/services to look at the history for last 7 days if in doubt

After merging this PR once the deploy is complete
1. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/services)
2. Optionally also run some production like workloads. `ark info -s` to get info like endpoint URL of the pod deployment.

In case of errors:
1. revert this PR
2. merge the deploy
