### PR TITLE
service step 2 of 4: dev to podOnly

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -86,7 +86,7 @@ alarms:
     threshold: 0.05
 pod_config:
   dev:
-    migrationState: deployable
+    migrationState: podOnly
   group: us-west-1
   prod:
     migrationState: deployable


### PR DESCRIPTION
This PR is the second step in migrating this service to pods

This PR will
- make all dev traffic go to pods

After merging this PR once the deploy is complete
1. `ark start --upstreams -e clever-dev <appName>`
2. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/services)
3. Optionally also run some production like workloads. `ark info -s` to get info like endpoint URL of the pod deployment.

In case of errors:
1. revert this PR
2. merge the deploy
3. `ark start --upstreams -e clever-dev <appName>`
