### PR TITLE
service step 3 of 4: prod to podOnly

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -89,4 +89,4 @@ pod_config:
     migrationState: podOnly
   group: us-west-1
   prod:
-    migrationState: deployable
+    migrationState: podOnly


### PR DESCRIPTION
This PR is the third step in migrating this service to pods

To check before merging
- external dns. If this repo has a public DNS then contact #oncall-infra for a followup to update the load balancers for that DNS record.

This PR will
- make traffic from all upstream apps go to pods in production

After merging this PR once the deploy is complete
1. `ark start --upstreams -e production <appName>`
2. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/services)

In case of errors:
1. revert this PR
2. merge the deploy
3. `ark start --upstreams -e production <appName>`
