### PR TITLE
service step 4 of 4: both to noHomepod

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -85,8 +85,4 @@ alarms:
   parameters:
     threshold: 0.05
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-1
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
This PR is the last step in migrating this service to pods

To check before merging
- external dns. If this repo has a public DNS then contact #oncall-infra for a followup to update the load balancers for that DNS record.
- hardcoded homepod URLs. sometimes the homepod URLs are hardcoded in other apps instead of using discovery. This is a good time to update those to either use discovery or use the new pod url.

This PR will
- update config to stop deploying in homepod

After merging this PR create a reminder to run kill-homepod for the app 3 days from now. This is because we want to wait sufficient time to verify no traffic is going to the homepod deployment. We recommend running the following two lines in slack
- `/remind [@someone] ark stop <app> -e clever-dev --kill-homepod in 3 days`
- `/remind [@someone] ark stop <app> -e production --kill-homepod in 3 days`

Note that `--kill-homepod` command will warn you if traffic was detected in the last 3 days so please read the warning carefully before proceeding
