### PR TITLE
migrate single region services to app mesh in hybrid state in prod

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -24,8 +24,8 @@ env:
 - SNOWFLAKE_ROLE
 - LATENCY_CONFIG
 resources:
-  cpu: 0.25
-  max_mem: 0.5
+  cpu: 0.5
+  max_mem: 1.0
 shepherds:
 - benji.stein@clever.com
 expose:


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5115

**Overview:**
In this PR we will migrate all internal single region services in this repo to use app mesh in hybrid state in **PROD**. After this PR the service will have both ALB and envoy proxy. 

When an app is in hybrid mode it's upstream can use either *.int.clever.com url or *.prod.mesh to communicate. On deploy if this app's downstream is in hybrid then we will use *.prod.mesh otherwise we will use *.int.clever.com. Eventually all apps will be restarted so that everthing is using envoy for communication. 

For more details on what each field in `mesh_config` means you can read https://app.getguru.com/card/TnAG64Gc/mesh_config-in-launchyml

Similar to other large scale infrastructure changes we expect some issues so if you think there are problems caused by this PR in prod please reach out to Tanmay or oncall-infra. 

For apps with cpu of 0.25 we are also bumping it to 0.5 as a precautionary measure to avoid issue from #flare-1417

**Rollout:**
- monitor cpu and memory

**Rollback:**
- ark rollback -e production <app>
- contact Tanmay or #oncall-infra