### PR TITLE
update from stretch to buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   common-executor:
     working_directory: /go/src/github.com/Clever/analytics-latency-config-service
     docker:
-    - image: circleci/golang:1.16-stretch-node
+    - image: circleci/golang:1.16-buster-node
     - image: circleci/postgres:9.4-alpine-ram
     - image: circleci/mongo:3.2.20-jessie-ram
       environment:


### PR DESCRIPTION
# oncall-infra

Update ci image from stretch to buster if CI is installing packages

There might be some CI failures in this PR, I will get to them eventually!

