### PR TITLE
migrate services with no traffic to mesh_only

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -91,4 +91,4 @@ mesh_config:
     state: mesh_only
   crossRegionRoute: non-sso
   prod:
-    state: hybrid
+    state: mesh_only


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5118

**Overview:**
This PR is part of the first cohort of apps that we are migrating from hybrid to mesh_only. All apps in this cohort are receiving 0 requests through their ALB so migrating them should be low risk.

This list of apps was generated programmatically by looking at ALB metrics for the last 2 days but double check grafana before merging. 

https://clever.grafana.net/d/Kyms8kdVz/applications-envoy-alb?orgId=1&from=now-2d&to=now

Risk associated with this rollout is quite low as going from hybrid to mesh only means that we are just deleting the ALB permanently. Since ALB metrics are 0 this should not cause issues.

**Rollout:**
- monitor cpu and memory
- monitor envoy metrics

**Rollback:**
- ark rollback -e clever-dev <app>
- contact Tanmay or #oncall-infra