### PR TITLE
clean up alarms

### DIFF
--- a/launch/analytics-latency-config-service.yml
+++ b/launch/analytics-latency-config-service.yml
@@ -48,27 +48,20 @@ alarms:
   parameters:
     threshold: 0.05
   extraParameters:
-    source: Total
     errorMinimum: 20
 - type: InternalErrorAlarm
   severity: major
   parameters:
     threshold: 0.01
-  extraParameters:
-    source: Total
 - type: InternalErrorAlarm
   severity: major
   parameters:
     threshold: 0.002
     evaluationPeriods: 5
-  extraParameters:
-    source: Total
 - type: InternalErrorAlarm
   severity: minor
   parameters:
     threshold: 0.001
-  extraParameters:
-    source: Total
 - type: BadRequestAlarm
   severity: major
   parameters:


### PR DESCRIPTION
# Clean up alarms for mesh services

## JIRA

https://clever.atlassian.net/browse/INFRANG-5475

## Overview

In Mesh there is no concept of alarm source of Target, ELB and Total as all metrics are coming from envoy sidecar. We are soon going to merge a change which will block CI for applications if source field is present for InternalErrorAlarms and mesh_config for prod set to mesh_only.

You have to review this PR to see that the new alarms make sense. It was hard to script all the different alarm setups we have across services. In most cases I have removed duplicate alarms but you might want to remove some more alarms or keep some deleted alarms.

## Rollout

Merge PR and deploy via dapple.
