### PR TITLE
remove unnecessary image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ executors:
     docker:
       - image: cimg/go:1.21-node
       - image: circleci/postgres:9.4-alpine-ram
-      - image: circleci/mongo:3.2.20-jessie-ram
         environment:
           GOPRIVATE: github.com/Clever/*
           POSTGRES_USER: postgres


### PR DESCRIPTION
**JIRA**:
https://clever.atlassian.net/browse/DEIP-1454

**Overview**:
This PR removes the unnecessary mongo circleci image from the build. This repo does not use mongo for anything so we don't need this line and it was confusing to have it here for the v6 upgrade.

**Testing**:
If the circleci build passes, we should be good.

**Roll Out**:
🚀 