### PR TITLE
Deip 1431 gosnowflake upgrade

### DIFF
--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -26,7 +26,7 @@ var _ = strconv.FormatInt
 var _ = bytes.Compare
 
 // Version of the client.
-const Version = "0.7.0"
+const Version = "0.7.1"
 
 // VersionHeader is sent with every request.
 const VersionHeader = "X-Client-Version"

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -681,7 +681,7 @@ module.exports.Errors = Errors;
 
 module.exports.DefaultCircuitOptions = defaultCircuitOptions;
 
-const version = "0.7.0";
+const version = "0.7.1";
 const versionHeader = "X-Client-Version";
 module.exports.Version = version;
 module.exports.VersionHeader = versionHeader;

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clever/analytics-latency-config-service",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Service for surfacing latency config settings for the analytics pipeline.",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -4,7 +4,7 @@ info:
   description: Service for surfacing latency config settings for the analytics pipeline.
   # when changing the version here, make sure to run
   # `make generate` to generate clients and server
-  version: 0.7.0
+  version: 0.7.1
   x-npm-package: '@clever/analytics-latency-config-service'
 schemes:
   - http


### PR DESCRIPTION
## Link to JIRA:
https://clever.atlassian.net/browse/DEIP-1431

## Overview:
Followup to https://github.com/Clever/analytics-latency-config-service/pull/34, forgot to bump version so that analytics-pipeline-monitor can get the right dependency I think?

If you made any changes to swagger.yml:
- [ ] Update swagger.yml version
- [ ] Run "make generate"

## Testing
This is a plain version bump with no functionality change

## Rollout
🚢 